### PR TITLE
Fix download location

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -19,7 +19,7 @@ readonly g_filename_template=__BINARY_NAME_____VERSION_SHORT_____PLATFORM__.tar.
 # available : __GITHUB_COORDINATES__/__VERSION__/__VERSION_SHORT__/__FILENAME__
 #
 # shellcheck disable=SC2034
-readonly g_download_url_template=https://github.com/__GITHUB_COORDINATES__/releases/download/__VERSION__/__FILENAME__
+readonly g_download_url_template=https://github.com/__GITHUB_COORDINATES__/releases/download/v__VERSION__/__FILENAME__
 #
 # available : __ARCHIVE_DIR__/__BINARY_NAME__/__VERSION__/__VERSION_SHORT__/__PLATFORM__
 #


### PR DESCRIPTION
Resolves #5 

```
$ asdf install conftest 0.20.0
[2021-09-10 10:05:30] INFO: Downloading [conftest] from https://github.com/open-policy-agent/conftest/releases/download/v0.20.0/conftest_0.20.0_Linux_x86_64.tar.gz to /tmp/asdf_J21TCn10/sub/conftest_0.20.0_Linux_x86_64.tar.gz (install_tool)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   643  100   643    0     0   3402      0 --:--:-- --:--:-- --:--:--  3384
100 11.1M  100 11.1M    0     0  7530k      0  0:00:01  0:00:01 --:--:--  9.8M
[2021-09-10 10:05:32] INFO: Creating bin directory [/home/myoung/.asdf/installs/conftest/0.20.0/bin] (install_tool)
[2021-09-10 10:05:32] INFO: Cleaning previous binaries if any (install_tool)
[2021-09-10 10:05:32] INFO: Extracting archive (install_tool)
[2021-09-10 10:05:32] INFO: Copying binaries (install_tool)
```